### PR TITLE
allow dot in id and any origins

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -9,8 +9,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins(/.*localhost:.*/)
-
+    origins "*"
     resource "*",
              headers: :any,
              methods: %i[get post put patch delete options head]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  resources :users, only: [:show]
-  resources :todos, only: %i[index create update destroy]
+  resources :users, only: [:show], constraints: { id: %r{[^/]+} }
+  resources :todos, only: %i[index create update destroy], constraints: { id: %r{[^/]+} }
 end


### PR DESCRIPTION
Allows ids in path params that contain special characters as `.`
Allow any origin